### PR TITLE
Feat/custom field in condition

### DIFF
--- a/TECHNIQUES.md
+++ b/TECHNIQUES.md
@@ -150,6 +150,30 @@ telecom_1:
        use: "work"
 ```
 
+**Note**: You can now test fields, components and sub-components
+from custom segments (Segments beginning with `Z`):
+
+```yml
+type_1:
+  condition: $zsc322 EQUALS H1 || $zsc322 EQUALS H2
+  generateList: false
+  expressionType: HL7Spec
+  valueOf: $code
+  vars:
+     zsc322: ZSC.3.2.2
+  constants:
+     code: allergy
+
+type_2:
+  condition: $zsc322 NOT_EQUALS H1 && $zsc322 NOT_EQUALS H2
+  generateList: false
+  expressionType: HL7Spec
+  valueOf: $code
+  vars:
+     zsc322: ZSC.3.2.2
+  constants:
+     code: intolerance
+```
 ### Referencing resources
 
 Resources are referenced (linked) in one of two ways:
@@ -323,4 +347,3 @@ The grammar for the condition field is as follows:
   *  `ZAL.3.1 NOT_IN [A2, F3, DA]`
   *  `ZAL.2 EQUALS A4`
   *  `ZAL NOT_EQUALS H2`
-  

--- a/src/main/java/io/github/linuxforhealth/core/expression/SimpleEvaluationResult.java
+++ b/src/main/java/io/github/linuxforhealth/core/expression/SimpleEvaluationResult.java
@@ -57,6 +57,7 @@ public class SimpleEvaluationResult<V> implements EvaluationResult {
     Preconditions.checkArgument(additionalResources != null, "additionalResources cannot be null");
     this.value = value;
 
+
     this.klass = value.getClass();
     this.klassName = DataTypeUtil.getDataType(value);
     this.additionalResources = new ArrayList<>();

--- a/src/main/java/io/github/linuxforhealth/core/expression/condition/ConditionPredicateEnum.java
+++ b/src/main/java/io/github/linuxforhealth/core/expression/condition/ConditionPredicateEnum.java
@@ -60,8 +60,11 @@ public enum ConditionPredicateEnum {
       String klassSimpleName) {
     // Append the predicate if not already present 
     // Some classes need a string predicate     
-    String klassAdjustedName = klassSimpleName.equalsIgnoreCase("ST") || klassSimpleName.equalsIgnoreCase("IS") || klassSimpleName.equalsIgnoreCase("NULLDT") ? "STRING" : klassSimpleName.toUpperCase();
-    String enumName = conditionOperator.endsWith(klassAdjustedName) ? conditionOperator : conditionOperator + "_" + klassSimpleName;
+    //   - Fields, Components & SubComponents from custom segments are in Varies or GenericPrimitive objects and are assumed to be STRING values
+    String klassAdjustedName = klassSimpleName.equals("Varies") || klassSimpleName.equals("GenericPrimitive") ||  klassSimpleName.equalsIgnoreCase("ST") || klassSimpleName.equalsIgnoreCase("IS") || klassSimpleName.equalsIgnoreCase("NULLDT") ? "STRING" : klassSimpleName.toUpperCase();
+
+    // Gotta be using the adjusted name - or what's the point of the adjustment?
+    String enumName = conditionOperator.endsWith(klassAdjustedName) ? conditionOperator : conditionOperator + "_" + klassAdjustedName;
     return EnumUtils.getEnumIgnoreCase(ConditionPredicateEnum.class, enumName);
 
   }

--- a/src/main/java/io/github/linuxforhealth/core/expression/condition/SimpleBiCondition.java
+++ b/src/main/java/io/github/linuxforhealth/core/expression/condition/SimpleBiCondition.java
@@ -32,11 +32,21 @@ public class SimpleBiCondition implements Condition {
   @Override
   public boolean test(Map<String, EvaluationResult> contextVariables) {
     Object var1Value = null;
+    String var1Type = null;
     EvaluationResult variable1;
     if (VariableUtils.isVar(var1)) {
       variable1 = contextVariables.get(VariableUtils.getVarName(var1));
+
+      if(VariableUtils.getVarName(var1).equals("zal21"))
+        System.out.println("Hello Stuey zal21");
+
       if (variable1 != null && !variable1.isEmpty()) {
         var1Value = variable1.getValue();
+
+        // generic variables (derived from fields,components & subComponents in custom segments) will have UNKNOWN type;
+        var1Type = variable1.getIdentifier();
+        if(var1Type.equals("UNKNOWN") && var1Value != null)
+            var1Type = var1Value.getClass().getSimpleName();
       }
     } else {
       throw new IllegalArgumentException("First value should be a variable");
@@ -49,12 +59,16 @@ public class SimpleBiCondition implements Condition {
       // Some classes have string values, but are not strings and must be converted first.
       if (var1Value.getClass().getTypeName().equalsIgnoreCase("ca.uhn.hl7v2.model.v26.datatype.ST")
       || var1Value.getClass().getTypeName().equalsIgnoreCase("ca.uhn.hl7v2.model.v26.datatype.IS")
-      || var1Value.getClass().getTypeName().equalsIgnoreCase("ca.uhn.hl7v2.model.v26.datatype.NULLDT")){
+      || var1Value.getClass().getTypeName().equalsIgnoreCase("ca.uhn.hl7v2.model.v26.datatype.NULLDT")
+
+      // When we get data back from CustomSegment fields,components or subComponents ...
+      || var1Value instanceof ca.uhn.hl7v2.model.Varies
+      || var1Value instanceof ca.uhn.hl7v2.model.GenericPrimitive) {
         var1Value = Hl7DataHandlerUtil.getStringValue(var1Value);
       }
     
       ConditionPredicateEnum condEnum = ConditionPredicateEnum
-          .getConditionPredicate(this.conditionOperator, variable1.getIdentifier());
+          .getConditionPredicate(this.conditionOperator, var1Type);
       if (condEnum != null) {
         // if var2 is a string and must be converted to an integer to test
         if (var2Value.getClass().getTypeName().equalsIgnoreCase("java.lang.String") 
@@ -100,6 +114,16 @@ public class SimpleBiCondition implements Condition {
     return conditionOperator;
   }
 
+  @Override
+  public String toString() {
+     java.io.StringWriter sw = new java.io.StringWriter();
+     sw.write(var1.toString());
+     sw.write(" ");
+     sw.write(conditionOperator);
+     sw.write(" ");
+     sw.write(var2.toString());
 
+     return sw.toString();
+  }
 
 }

--- a/src/test/java/io/github/linuxforhealth/hl7/expression/Hl7ExpressionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/expression/Hl7ExpressionTest.java
@@ -18,6 +18,8 @@ import ca.uhn.hl7v2.model.Structure;
 import ca.uhn.hl7v2.model.Type;
 import io.github.linuxforhealth.api.EvaluationResult;
 import io.github.linuxforhealth.core.expression.SimpleEvaluationResult;
+import io.github.linuxforhealth.core.expression.condition.ConditionUtil;
+import io.github.linuxforhealth.core.expression.condition.SimpleBiCondition;
 import io.github.linuxforhealth.core.terminology.SimpleCode;
 import io.github.linuxforhealth.hl7.message.HL7MessageData;
 import io.github.linuxforhealth.hl7.parsing.HL7DataExtractor;
@@ -123,8 +125,10 @@ class Hl7ExpressionTest {
 
   }
 
+
+  // PID.3.1 is a COMPONENT
   @Test
-  void test3_field_subcomponent() throws IOException {
+  void test3_field_component() throws IOException {
     String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
         + "EVN|A01|20130617154644\r"
         + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
@@ -158,7 +162,80 @@ class Hl7ExpressionTest {
 
   }
 
+  // PID.5.1.3 is a SUBCOMPONENT
+  @Test
+  void test3_field_subcomponent() throws IOException {
+    String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
+        + "EVN|A01|20130617154644\r"
+        + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|&van der&Westhuizen^Cornelius^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
+        + "NK1|1|Wood^John^^^MR|Father||999-9999\r" + "NK1|2|Jones^Georgie^^^MSS|MOTHER||999-9999\r"
+        + "PV1|1||Location||||||||||||||||261938_6_201306171546|||||||||||||||||||||||||20130617134644|||||||||";
 
+    Message hl7message = getMessage(message);
+
+    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+
+
+    Structure s = hl7DTE.getStructure("PID", 0).getValue();
+
+
+    ExpressionAttributes attr =
+        new ExpressionAttributes.Builder().withSpecs("PID.5.1.3").withType("String").build();
+    Hl7Expression exp = new Hl7Expression(attr);
+
+
+    Map<String, EvaluationResult> context = new HashMap<>();
+    // context.put("PID", new SimpleEvaluationResult(s));
+
+
+    EvaluationResult value = exp.evaluate(new HL7MessageData(hl7DTE), ImmutableMap.copyOf(context),
+        new SimpleEvaluationResult(s));
+
+
+    assertThat((String) value.getValue()).isEqualTo("Westhuizen");
+  }
+
+  // ZAL.2.1 is a COMPONENT in a custom SEGMENT
+  @Test
+  void test3_field_customcomponent() throws IOException {
+    String message = "MSH|^~\\&|hl7Integration|hl7Integration|||||ADT^A01|||2.3|\r"
+        + "EVN|A01|20130617154644\r"
+        + "PID|1|465 306 5961|000010016^^^MR~000010017^^^MR~000010018^^^MR|407623|Wood^Patrick^^^MR||19700101|female|||High Street^^Oxford^^Ox1 4DP~George St^^Oxford^^Ox1 5AP|||||||\r"
+        + "NK1|1|Wood^John^^^MR|Father||999-9999\r" + "NK1|2|Jones^Georgie^^^MSS|MOTHER||999-9999\r"
+        + "PV1|1||Location||||||||||||||||261938_6_201306171546|||||||||||||||||||||||||20130617134644|||||||||\r"
+        + "ZAL|1|H3^Other allergies^webPAS|L01^Latex^webPAS|";
+
+
+    Message hl7message = getMessage(message);
+
+    HL7DataExtractor hl7DTE = new HL7DataExtractor(hl7message);
+
+
+    Structure s = hl7DTE.getStructure("ZAL", 0).getValue();
+
+
+    ExpressionAttributes attr =
+        new ExpressionAttributes.Builder().withSpecs("ZAL.2.1").withType("String").build();
+    Hl7Expression exp = new Hl7Expression(attr);
+
+
+    Map<String, EvaluationResult> context = new HashMap<>();
+    // context.put("PID", new SimpleEvaluationResult(s));
+
+
+    EvaluationResult value = exp.evaluate(new HL7MessageData(hl7DTE), ImmutableMap.copyOf(context),
+        new SimpleEvaluationResult(s));
+
+
+    assertThat((String) value.getValue()).isEqualTo("H3");
+
+    // Can we stick it into a variable and make it work in a Condition ?
+    SimpleBiCondition simplecondition = (SimpleBiCondition) ConditionUtil.createCondition("$zal21 EQUALS H3");
+    Map<String, EvaluationResult> contextVariables = new HashMap<>();
+    contextVariables.put("zal21", value);
+    
+    assertThat(simplecondition.test(contextVariables)).isTrue();
+}
 
   @Test
   void test3_field_options() throws IOException {

--- a/src/test/java/io/github/linuxforhealth/hl7/message/Hl7CustomSegmentConditionTest.java
+++ b/src/test/java/io/github/linuxforhealth/hl7/message/Hl7CustomSegmentConditionTest.java
@@ -1,0 +1,241 @@
+/*
+ * (c) Te Whatu Ora, Health New Zealand, 2023
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * 
+ * @author Stuart McGrigor
+ */
+
+package io.github.linuxforhealth.hl7.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.Properties;
+
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.AllergyIntolerance;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
+import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.r4.model.ResourceType;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import io.github.linuxforhealth.core.config.ConverterConfiguration;
+import io.github.linuxforhealth.fhir.FHIRContext;
+import io.github.linuxforhealth.hl7.ConverterOptions;
+import io.github.linuxforhealth.hl7.ConverterOptions.Builder;
+import io.github.linuxforhealth.hl7.HL7ToFHIRConverter;
+import io.github.linuxforhealth.hl7.resource.ResourceReader;
+import io.github.linuxforhealth.hl7.segments.util.ResourceUtils;
+
+// This class uses the ability to create ADDITIONAL HL7 messages to convert weird HL7 messages
+// that exercise the new conditional Resource Template functionality
+//
+// In these tests, the additional message definitions for (entirely ficticious) ADT^A11 messages
+// are placed in src/test/resources/additional_resources/hl7/message/ADT_A11.yml
+//
+// ... and the mappings are placed in src/test/resources/hl7/resource/AllergyIntoleranceZ*.yml
+//
+//  We are verifying that we can extract FIELD, COMPONENT and SUB COMPONENT values from custom segments and use those
+//  values in conditions.
+
+class Hl7CustomSegmentConditionTest {
+
+    // # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+    // NOTE VALIDATION IS INTENTIONALLY NOT USED BECAUSE WE ARE CREATING RESOURCES THAT ARE NOT STANDARD
+    private static final ConverterOptions OPTIONS = new Builder().withPrettyPrint().build();
+    // # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+    private static final String CONF_PROP_HOME = "hl7converter.config.home";
+
+    @TempDir
+    static File folder;
+
+    static String originalConfigHome;
+
+    @BeforeAll
+    static void saveConfigHomeProperty() {
+        originalConfigHome = System.getProperty(CONF_PROP_HOME);
+        ConverterConfiguration.reset();
+        ResourceReader.reset();
+        folder.setWritable(true);
+    }
+
+    @AfterEach
+    void reset() {
+        System.clearProperty(CONF_PROP_HOME);
+        ConverterConfiguration.reset();
+        ResourceReader.reset();
+    }
+
+    @AfterAll
+    static void reloadPreviousConfigurations() {
+        if (originalConfigHome != null)
+            System.setProperty(CONF_PROP_HOME, originalConfigHome);
+        else
+            System.clearProperty(CONF_PROP_HOME);
+        folder.setWritable(true);
+    }
+
+
+    // Custom Segment Field Condition Test ZFD
+    @ParameterizedTest
+    @CsvSource({ "ADT^A11,ZFD|1|L2|H1|four\r,ALLERGY",      // ZFD.3 = H1 --> allergy
+                 "ADT^A11,ZFD|1|L2|H2|four\r,ALLERGY",      // ZFD.3 = H2 --> allergy
+                 "ADT^A11,ZFD|1|L2|H3|four\r,INTOLERANCE",  // ZFD.3 = H3 --> intolerance
+                })
+    void testCustomSegmentFieldInCondition(String messageType, String zSegment, String aiType) throws IOException {
+
+        // Set up the config file
+        commonConfigFileSetup();
+
+        // An empty AL1 Segment...
+        String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + messageType + "|controlID|P|2.6\r"
+                + "EVN|A01|20150502090000|\r"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+                + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\r"
+                + zSegment;
+
+        List<BundleEntryComponent> e = getBundleEntryFromHL7Message(hl7message);
+
+        List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
+        assertThat(patientResource).hasSize(1); // from PID
+
+        List<Resource> encounterResource = ResourceUtils.getResourceList(e, ResourceType.Encounter);
+        assertThat(encounterResource).hasSize(1); // from EVN, PV1
+
+        List<Resource> allergyIntoleranceResources = ResourceUtils.getResourceList(e, ResourceType.AllergyIntolerance);
+        assertThat(allergyIntoleranceResources).hasSize(1)   // from ZFD segment
+            .element(0).satisfies(ai -> {
+
+                // Make sure the type field is present & correct
+                assertThat(((AllergyIntolerance) ai).hasType()).isTrue();
+                assertThat(((AllergyIntolerance) ai).getType()).hasToString(aiType);
+            });
+
+
+
+        // Confirm that there are no extra resources
+        assertThat(e).hasSize(3);
+    }
+
+
+    // Custom Segment COMPONENT Condition Test ZCP
+    @ParameterizedTest
+    @CsvSource({ "ADT^A11,ZCP|1|A3^yy|xx^H1|four\r,ALLERGY",      // ZCP.3.2 = H1 --> allergy
+                 "ADT^A11,ZCP|1|A3^yy|xx^H2|four\r,ALLERGY",      // ZCP.3.2 = H2 --> allergy
+                 "ADT^A11,ZCP|1|A3^yy|xx^H3|four\r,INTOLERANCE",  // ZCP.3.2 = H3 --> intolerance
+                })
+    void testCustomSegmentComponentInCondition(String messageType, String zSegment, String aiType) throws IOException {
+
+        // Set up the config file
+        commonConfigFileSetup();
+
+        // An empty AL1 Segment...
+        String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + messageType + "|controlID|P|2.6\r"
+                + "EVN|A01|20150502090000|\r"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+                + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\r"
+                + zSegment;
+
+        List<BundleEntryComponent> e = getBundleEntryFromHL7Message(hl7message);
+
+        List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
+        assertThat(patientResource).hasSize(1); // from PID
+
+        List<Resource> encounterResource = ResourceUtils.getResourceList(e, ResourceType.Encounter);
+        assertThat(encounterResource).hasSize(1); // from EVN, PV1
+
+        List<Resource> allergyIntoleranceResources = ResourceUtils.getResourceList(e, ResourceType.AllergyIntolerance);
+        assertThat(allergyIntoleranceResources).hasSize(1)   // from ZFD segment
+            .element(0).satisfies(ai -> {
+
+                // Make sure the type field is present & correct
+                assertThat(((AllergyIntolerance) ai).hasType()).isTrue();
+                assertThat(((AllergyIntolerance) ai).getType()).hasToString(aiType);
+            });
+
+
+
+        // Confirm that there are no extra resources
+        assertThat(e).hasSize(3);
+    }
+
+
+    // Custom Segment SUBCOMPONENT Condition Test ZCP
+    @ParameterizedTest
+    @CsvSource({ "ADT^A11,ZSC|1|zz&A3^yy|xx^ww&H1|four\r,ALLERGY",      // ZCP.3.2.2 = H1 --> allergy
+                 "ADT^A11,ZSC|1|zz&A3^yy|xx^ww&H2|four\r,ALLERGY",      // ZCP.3.2.2 = H2 --> allergy
+                 "ADT^A11,ZSC|1|zz&A3^yy|xx^ww&H3|four\r,INTOLERANCE",  // ZCP.3.2.2 = H3 --> intolerance
+                })
+    void testCustomSegmentSubComponentInCondition(String messageType, String zSegment, String aiType) throws IOException {
+
+        // Set up the config file
+        commonConfigFileSetup();
+
+        // An empty AL1 Segment...
+        String hl7message = "MSH|^~\\&|TestSystem||TestTransformationAgent||20150502090000||" + messageType + "|controlID|P|2.6\r"
+                + "EVN|A01|20150502090000|\r"
+                + "PID|||1234^^^^MR||DOE^JANE^|||F||||||||||||||||||||||\r"
+                + "PV1||I||||||||SUR||||||||S|VisitNumber^^^ACME|A||||||||||||||||||||||||20150502090000|\r"
+                + zSegment;
+
+        List<BundleEntryComponent> e = getBundleEntryFromHL7Message(hl7message);
+
+        List<Resource> patientResource = ResourceUtils.getResourceList(e, ResourceType.Patient);
+        assertThat(patientResource).hasSize(1); // from PID
+
+        List<Resource> encounterResource = ResourceUtils.getResourceList(e, ResourceType.Encounter);
+        assertThat(encounterResource).hasSize(1); // from EVN, PV1
+
+        List<Resource> allergyIntoleranceResources = ResourceUtils.getResourceList(e, ResourceType.AllergyIntolerance);
+        assertThat(allergyIntoleranceResources).hasSize(1)   // from ZFD segment
+            .element(0).satisfies(ai -> {
+
+                // Make sure the type field is present & correct
+                assertThat(((AllergyIntolerance) ai).hasType()).isTrue();
+                assertThat(((AllergyIntolerance) ai).getType()).hasToString(aiType);
+            });
+
+
+
+        // Confirm that there are no extra resources
+        assertThat(e).hasSize(3);
+    }
+
+
+
+    private static void commonConfigFileSetup() throws IOException {
+        File configFile = new File(folder, "config.properties");
+        Properties prop = new Properties();
+        prop.put("base.path.resource", "src/main/resources");
+        prop.put("supported.hl7.messages", "ADT_A11"); // Must need to define our weird ADT message
+        prop.put("default.zoneid", "+08:00");
+        // Location of custom (or merely additional) resources
+        prop.put("additional.resources.location",  "src/test/resources/additional_resources");
+        prop.store(new FileOutputStream(configFile), null);
+        System.setProperty(CONF_PROP_HOME, configFile.getParent());
+    }
+
+    // Need custom convert sequence with options that turn off FHIR validation.
+    private static List<BundleEntryComponent> getBundleEntryFromHL7Message(String hl7message) {
+        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter(); // Testing loading of config which happens once per instantiation
+        String json = ftv.convert(hl7message, OPTIONS); // Need custom options that turn off FHIR validation.
+        assertThat(json).isNotNull();
+        FHIRContext context = new FHIRContext();
+        IBaseResource bundleResource = context.getParser().parseResource(json);
+        assertThat(bundleResource).isNotNull();
+        Bundle b = (Bundle) bundleResource;
+        return b.getEntry();
+    }
+
+}

--- a/src/test/resources/additional_resources/hl7/message/ADT_A11.yml
+++ b/src/test/resources/additional_resources/hl7/message/ADT_A11.yml
@@ -59,7 +59,7 @@ resources:
     # FIELD - based condition
     - resourceName: AllergyIntolerance
       segment: ZFD
-      resourcePath: resource/AllergyIntolerance  ## The AllergyIntolerance will be badly filled in
+      resourcePath: resource/AllergyIntoleranceZFD  ## The AllergyIntolerance will be badly filled in
       condition: ZFD.2 EQUALS L2
       repeats: true
       additionalSegments:
@@ -68,7 +68,7 @@ resources:
     # COMPONENT based condition
     - resourceName: AllergyIntolerance
       segment: ZCP
-      resourcePath: resource/AllergyIntolerance  ## The AllergyIntolerance will be badly filled in
+      resourcePath: resource/AllergyIntoleranceZCP  ## The AllergyIntolerance will be badly filled in
       condition: ZCP.2.1 IN [A3, A4, H1, H3]
       repeats: true
       additionalSegments:
@@ -77,7 +77,7 @@ resources:
     # COMPONENT based condition (repetition)
     - resourceName: AllergyIntolerance
       segment: ZCR
-      resourcePath: resource/AllergyIntolerance  ## The AllergyIntolerance will be badly filled in
+      resourcePath: resource/AllergyIntoleranceZCP  ## The AllergyIntolerance will be badly filled in
       condition: ZCR.2(1).1 IN [A3, A4, H1, H3]
       repeats: true
       additionalSegments:
@@ -86,7 +86,7 @@ resources:
     # SUB COMPONENT based condition
     - resourceName: AllergyIntolerance
       segment: ZSC
-      resourcePath: resource/AllergyIntolerance  ## The AllergyIntolerance will be badly filled in
+      resourcePath: resource/AllergyIntoleranceZSC  ## The AllergyIntolerance will be badly filled in
       condition: ZSC.2.1.2 IN [A3, A4, H1, H3]
       repeats: true
       additionalSegments:

--- a/src/test/resources/hl7/resource/AllergyIntoleranceZCP.yml
+++ b/src/test/resources/hl7/resource/AllergyIntoleranceZCP.yml
@@ -1,0 +1,48 @@
+#
+# (c) Te Whatu Ora, Health New Zealand, 2023
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+## pretend AllergyIntolerance from ZCP custom segment
+##   - actually for testing use of custom segment COMPONENT in conditions.
+---
+resourceType: AllergyIntolerance
+
+type_1:
+  condition: $zcp32 EQUALS H1 || $zcp32 EQUALS H2
+  generateList: false
+  expressionType: HL7Spec
+  valueOf: $code
+  vars:
+     zcp32: ZCP.3.2
+  constants:
+     code: allergy
+
+type_2:
+  condition: $zcp32 NOT_EQUALS H1 && $zcp32 NOT_EQUALS H2
+  generateList: false
+  expressionType: HL7Spec
+  valueOf: $code
+  vars:
+     zcp32: ZCP.3.2
+  constants:
+     code: intolerance
+
+clinicalStatus:
+  valueOf: datatype/CodeableConcept_var
+  generateList: true
+  expressionType: resource
+  constants:
+    system: "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical"
+    code: "activeXXX"
+    display: "Active"
+
+verificationStatus:
+  valueOf: datatype/CodeableConcept_var
+  generateList: true
+  expressionType: resource
+  constants:
+    system: "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification"
+    code: "confirmed"
+    display: "Confirmed"
+

--- a/src/test/resources/hl7/resource/AllergyIntoleranceZFD.yml
+++ b/src/test/resources/hl7/resource/AllergyIntoleranceZFD.yml
@@ -1,0 +1,48 @@
+#
+# (c) Te Whatu Ora, Health New Zealand, 2023
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+## pretend AllergyIntolerance from ZFD custom segment
+##   - actually for testing use of custom segment fields in conditions.
+---
+resourceType: AllergyIntolerance
+
+type_1:
+  condition: $zfd3 EQUALS H1 || $zfd3 EQUALS H2
+  generateList: false
+  expressionType: HL7Spec
+  valueOf: $code
+  vars:
+     zfd3: ZFD.3
+  constants:
+     code: allergy
+
+type_2:
+  condition: $zfd3 NOT_EQUALS H1 && $zfd3 NOT_EQUALS H2
+  generateList: false
+  expressionType: HL7Spec
+  valueOf: $code
+  vars:
+     zfd3: ZFD.3
+  constants:
+     code: intolerance
+
+clinicalStatus:
+  valueOf: datatype/CodeableConcept_var
+  generateList: true
+  expressionType: resource
+  constants:
+    system: "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical"
+    code: "activeXXX"
+    display: "Active"
+
+verificationStatus:
+  valueOf: datatype/CodeableConcept_var
+  generateList: true
+  expressionType: resource
+  constants:
+    system: "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification"
+    code: "confirmed"
+    display: "Confirmed"
+

--- a/src/test/resources/hl7/resource/AllergyIntoleranceZSC.yml
+++ b/src/test/resources/hl7/resource/AllergyIntoleranceZSC.yml
@@ -1,0 +1,48 @@
+#
+# (c) Te Whatu Ora, Health New Zealand, 2023
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+## pretend AllergyIntolerance from ZCP custom segment
+##   - actually for testing use of custom segment COMPONENT in conditions.
+---
+resourceType: AllergyIntolerance
+
+type_1:
+  condition: $zsc322 EQUALS H1 || $zsc322 EQUALS H2
+  generateList: false
+  expressionType: HL7Spec
+  valueOf: $code
+  vars:
+     zsc322: ZSC.3.2.2
+  constants:
+     code: allergy
+
+type_2:
+  condition: $zsc322 NOT_EQUALS H1 && $zsc322 NOT_EQUALS H2
+  generateList: false
+  expressionType: HL7Spec
+  valueOf: $code
+  vars:
+     zsc322: ZSC.3.2.2
+  constants:
+     code: intolerance
+
+clinicalStatus:
+  valueOf: datatype/CodeableConcept_var
+  generateList: true
+  expressionType: resource
+  constants:
+    system: "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical"
+    code: "activeXXX"
+    display: "Active"
+
+verificationStatus:
+  valueOf: datatype/CodeableConcept_var
+  generateList: true
+  expressionType: resource
+  constants:
+    system: "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification"
+    code: "confirmed"
+    display: "Confirmed"
+


### PR DESCRIPTION
Now that we can access custom segment fields (ZAL-3), components (ZAL-3.1) and sub components (ZAL-3.2.1) we also need to be able to use those values in conditions:

```yaml
type_1:
  condition: $zcp32 EQUALS H1 || $zcp32 EQUALS H2
  generateList: false
  expressionType: HL7Spec
  valueOf: $code
  vars:
     zcp32: ZCP.3.2
  constants:
     code: allergy
```
